### PR TITLE
Url validator

### DIFF
--- a/.brokignore
+++ b/.brokignore
@@ -1,0 +1,2 @@
+https://example.com
+https://www.example.com

--- a/.github/workflows/url-auditor.yml
+++ b/.github/workflows/url-auditor.yml
@@ -36,4 +36,4 @@ jobs:
         dpkg -i brok-1.1.0_x86-64-linux.deb
     - name: Run brok
       run: |
-        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md") > /dev/null
+        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md")

--- a/.github/workflows/url-auditor.yml
+++ b/.github/workflows/url-auditor.yml
@@ -1,0 +1,39 @@
+name: URL validator
+
+on: [push, pull_request]
+
+jobs:
+  Pre-Commit:
+    name: Run brok Against files in repo
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:bullseye-slim
+
+    steps:
+
+    - name: Install System Deps
+      run: |
+        apt-get update
+        apt-get install -y wget libtinfo5
+
+    - uses: actions/checkout@v2
+
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y%m")"
+      shell: bash
+    - uses: actions/cache@v2
+      with:
+        path: .brokdb
+        key: ${{ hashFiles('.github/workflows/url-check.yml') }}-${{ hashFiles('.brokignore') }}-${{ steps.get-date.outputs.date }}
+
+    - name: Install brok
+      run: |
+        wget https://github.com/smallhadroncollider/brok/releases/download/1.1.0/brok-1.1.0_x86-64-linux.deb
+        dpkg -i brok-1.1.0_x86-64-linux.deb
+    - name: Run brok
+      run: |
+        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md") > /dev/null

--- a/.github/workflows/url-auditor.yml
+++ b/.github/workflows/url-auditor.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: .brokdb
-        key: ${{ hashFiles('.github/workflows/url-check.yml') }}-${{ hashFiles('.brokignore') }}-${{ steps.get-date.outputs.date }}
+        key: ${{ hashFiles('.github/workflows/url-auditor.yml') }}-${{ hashFiles('.brokignore') }}-${{ steps.get-date.outputs.date }}
 
     - name: Install brok
       run: |


### PR DESCRIPTION
Can either choose to have verbose output or suppressed output (only show output on error) with the `Run brok` step.

To compare:

- Verbose output under `Run brok` job: https://github.com/dendronhq/dendron-blog/runs/3502142319?check_suite_focus=true
- Suppressed output under `Run brok` job (no output, because no errors/failures): https://github.com/dendronhq/dendron-blog/runs/3480266714?check_suite_focus=true

Currently, Verbose output is used. This helps verify that it is actually scanning URLs. Can choose to suppress on larger vaults?