### PR TITLE
Publish Dendron with Netlify

### DIFF
--- a/vault/blog.2020.2020-08-24-a-hierarchy-first-approach-to-note-taking.md
+++ b/vault/blog.2020.2020-08-24-a-hierarchy-first-approach-to-note-taking.md
@@ -1,7 +1,7 @@
 ---
 id: 3dd58f62-fee5-4f93-b9f1-b0f0f59a9b64
 title: A Hierarchy First Approach to Note Taking
-updated: 1635400128807
+updated: 1638758312714
 created: 1598210596673
 date: '2020-08-24'
 tags:
@@ -267,7 +267,7 @@ A little over a year ago, I left my job at Amazon to work on a note-taking tool 
 
 ## Dendron
 
-About a month ago, I launched the preview for [Dendron](https://dendron.so/). Dendron is the first-ever note-taking tool built from the ground up to support hierarchical note-taking. Dendron is open source, local first, Markdown-based, and runs as a collection of extension on top of VSCode.
+About a month ago, I launched the preview for [Dendron](https://link.dendron.so/home). Dendron is the first-ever note-taking tool built from the ground up to support hierarchical note-taking. Dendron is open source, local first, Markdown-based, and runs as a collection of extension on top of VSCode.
 
 Dendron lives inside VSCode because I wanted to move fast and focus on the truly novel parts of hierarchical notes without also building all the scaffolding that comes from creating an editor. Living inside VSCode means that users also have access to the thousands of existing extensions that provide everything from [vim keybindings](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) to [realtime collaboration editing](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare). 
 

--- a/vault/blog.2020.2020-08-24-a-hierarchy-first-approach-to-note-taking.md
+++ b/vault/blog.2020.2020-08-24-a-hierarchy-first-approach-to-note-taking.md
@@ -1,7 +1,7 @@
 ---
 id: 3dd58f62-fee5-4f93-b9f1-b0f0f59a9b64
 title: A Hierarchy First Approach to Note Taking
-updated: 1638758312714
+updated: 1638832947589
 created: 1598210596673
 date: '2020-08-24'
 tags:
@@ -267,7 +267,7 @@ A little over a year ago, I left my job at Amazon to work on a note-taking tool 
 
 ## Dendron
 
-About a month ago, I launched the preview for [Dendron](https://link.dendron.so/home). Dendron is the first-ever note-taking tool built from the ground up to support hierarchical note-taking. Dendron is open source, local first, Markdown-based, and runs as a collection of extension on top of VSCode.
+About a month ago, I launched the preview for [Dendron](https://www.dendron.so/). Dendron is the first-ever note-taking tool built from the ground up to support hierarchical note-taking. Dendron is open source, local first, Markdown-based, and runs as a collection of extension on top of VSCode.
 
 Dendron lives inside VSCode because I wanted to move fast and focus on the truly novel parts of hierarchical notes without also building all the scaffolding that comes from creating an editor. Living inside VSCode means that users also have access to the thousands of existing extensions that provide everything from [vim keybindings](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) to [realtime collaboration editing](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare). 
 

--- a/vault/blog.2021.2021-04-09-dendron-inc.md
+++ b/vault/blog.2021.2021-04-09-dendron-inc.md
@@ -2,7 +2,7 @@
 id: N9VxT7G5SovmncezBAGO2
 title: Dendron Inc
 desc: ''
-updated: 1635291264579
+updated: 1638758273288
 created: 1624123542935
 excerpt: We are launching a company
 canonicalUrl: 'https://wiki.dendron.so/notes/8d6bb6c6-f2b5-4fb4-a7f0-1930b528051f.html'
@@ -17,7 +17,7 @@ It was trying to answer these questions that led me to experiment and ultimately
 
 A year ago, I launched [Dendron](https://wiki.dendron.so/) to see if this system I developed would work for anyone else - now 3000 commits and 27,000 downloads later, I'm happy to say that it does. I get a thrill every time someone messages me about how they're using Dendron - whether it's planning out their next Dungeons and Dragons game or it's using Dendron as the central knowledge base for both work and home.
 
-What makes Dendron powerful is our ability to let users organize their information in a way that's most useful to them. Dendron takes many of the affordances developers are used to in code, like abstractions ([note references](https://wiki.dendron.so/notes/f1af56bb-db27-47ae-8406-61a98de6c78c.html)), [refactoring](https://wiki.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47.html#refactor-hierarchy), and [symbol lookup](https://wiki.dendron.so/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3.html) and applying it to general knowledge.
+What makes Dendron powerful is our ability to let users organize their information in a way that's most useful to them. Dendron takes many of the affordances developers are used to in code, like abstractions ([note references](https://link.dendron.so/6WvT)), [refactoring](https://link.dendron.so/6WvW), and [symbol lookup](https://link.dendron.so/6WvY) and applying it to general knowledge.
 
 These capabilities combined with our model of working over plaintext markdown and our open source license means that your knowledge is always yours, available instantly and in any way you want it.
 
@@ -25,7 +25,7 @@ Moving forward, we will further expand on Dendron's capabilities to make it a fu
 
 Rest assured that nothing is changing about the way we do things - Dendron will remain open source and the client will always be local first and free. We plan to make money by charging teams and enterprises who want access to additional features like single sign-on, private registries and fine-grained access control.
 
-As part of our growth from a project to a company, we are also publishing the [Dendron Handbook](https://handbook.dendron.so/). This is **heavily inspired** from the [Gitlab Handbook](https://about.gitlab.com/handbook/) and will document our mission, values, and roadmap as a company.
+As part of our growth from a project to a company, we are also publishing the [Dendron Handbook](https://link.dendron.so/handbook). This is **heavily inspired** from the [Gitlab Handbook](https://about.gitlab.com/handbook/) and will document our mission, values, and roadmap as a company.
 
 From day one, the words of Vannevar Bush, originator of the [memex](https://en.wikipedia.org/wiki/Memex), has been our north star
 
@@ -33,7 +33,7 @@ From day one, the words of Vannevar Bush, originator of the [memex](https://en.w
 
 Our goal is to help humans take **command over the inherited knowledge of the ages**. We welcome you to be part of our journey :)
 
-(and we are [hiring](https://wiki.dendron.so/notes/c378b702-7d49-4e91-be6e-b2078103c86e.html))
+(and we are [hiring](https://link.dendron.so/careers))
 
 ---
 

--- a/vault/blog.2021.2021-04-09-dendron-inc.md
+++ b/vault/blog.2021.2021-04-09-dendron-inc.md
@@ -2,7 +2,7 @@
 id: N9VxT7G5SovmncezBAGO2
 title: Dendron Inc
 desc: ''
-updated: 1638758273288
+updated: 1638833465061
 created: 1624123542935
 excerpt: We are launching a company
 canonicalUrl: 'https://wiki.dendron.so/notes/8d6bb6c6-f2b5-4fb4-a7f0-1930b528051f.html'
@@ -17,7 +17,7 @@ It was trying to answer these questions that led me to experiment and ultimately
 
 A year ago, I launched [Dendron](https://wiki.dendron.so/) to see if this system I developed would work for anyone else - now 3000 commits and 27,000 downloads later, I'm happy to say that it does. I get a thrill every time someone messages me about how they're using Dendron - whether it's planning out their next Dungeons and Dragons game or it's using Dendron as the central knowledge base for both work and home.
 
-What makes Dendron powerful is our ability to let users organize their information in a way that's most useful to them. Dendron takes many of the affordances developers are used to in code, like abstractions ([note references](https://link.dendron.so/6WvT)), [refactoring](https://link.dendron.so/6WvW), and [symbol lookup](https://link.dendron.so/6WvY) and applying it to general knowledge.
+What makes Dendron powerful is our ability to let users organize their information in a way that's most useful to them. Dendron takes many of the affordances developers are used to in code, like abstractions ([note references](https://wiki.dendron.so/notes/f1af56bb-db27-47ae-8406-61a98de6c78c/), [refactoring](https://wiki.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47/#refactor-hierarchy), and [symbol lookup](https://wiki.dendron.so/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3/)) and applying it to general knowledge.
 
 These capabilities combined with our model of working over plaintext markdown and our open source license means that your knowledge is always yours, available instantly and in any way you want it.
 
@@ -25,7 +25,7 @@ Moving forward, we will further expand on Dendron's capabilities to make it a fu
 
 Rest assured that nothing is changing about the way we do things - Dendron will remain open source and the client will always be local first and free. We plan to make money by charging teams and enterprises who want access to additional features like single sign-on, private registries and fine-grained access control.
 
-As part of our growth from a project to a company, we are also publishing the [Dendron Handbook](https://link.dendron.so/handbook). This is **heavily inspired** from the [Gitlab Handbook](https://about.gitlab.com/handbook/) and will document our mission, values, and roadmap as a company.
+As part of our growth from a project to a company, we are also publishing the [Dendron Handbook](https://handbook.dendron.so/). This is **heavily inspired** from the [Gitlab Handbook](https://about.gitlab.com/handbook/) and will document our mission, values, and roadmap as a company.
 
 From day one, the words of Vannevar Bush, originator of the [memex](https://en.wikipedia.org/wiki/Memex), has been our north star
 
@@ -33,7 +33,7 @@ From day one, the words of Vannevar Bush, originator of the [memex](https://en.w
 
 Our goal is to help humans take **command over the inherited knowledge of the ages**. We welcome you to be part of our journey :)
 
-(and we are [hiring](https://link.dendron.so/careers))
+(and we are [hiring](https://wiki.dendron.so/notes/c378b702-7d49-4e91-be6e-b2078103c86e/))
 
 ---
 

--- a/vault/blog.2021.2021-06-28-seed-bank.md
+++ b/vault/blog.2021.2021-06-28-seed-bank.md
@@ -2,7 +2,7 @@
 id: qTeL51LFD0Y8uC9ect7QV
 title: The Dendron Seed Bank - A Public Registry for General Knowledge
 desc: ''
-updated: 1638757781614
+updated: 1638833116422
 created: 1624562569744
 date: '2021-06-28'
 excerpt: "Github for knowledge"
@@ -22,7 +22,7 @@ Today, we are announcing the preview of the Seed Bank - a public registry for ge
 
 If you're familiar with package managers like npm, it's kind of like that but for any sort of information, not just code.
 
-The seed bank makes it easy to **discover, reference, and grow** information on things that you care about. This could be a guide on [personal knowledge management](https://link.dendron.so/6Wu_) or a reference to everything [AWS](https://link.dendron.so/6Wv0)
+The seed bank makes it easy to **discover, reference, and grow** information on things that you care about. This could be a guide on [personal knowledge management](https://pkm.dendron.so/) or a reference to everything [AWS](https://aws.dendron.so/)
 
 With the seed bank, you no longer need to start from zero when looking stuff up - rather, you have a single source of reference that you can grow over time.
 
@@ -39,7 +39,7 @@ You already use Dendron as a daily journal to track your tasks and you are tired
 
 Because the seed bank is currently in preview, you open up a shell and navigate to your workspace. Since you already have dendron open in vscode, you run `> Create new Integrated Terminal` to open up a shell. 
 
-Because you already have the [dendron-cli](https://link.dendron.so/6Wv7) installed, you can run the following command
+Because you already have the [dendron-cli](https://wiki.dendron.so/notes/23a1b942-99af-45c8-8116-4f4bb7dccd21/) installed, you can run the following command
 
 ```
 dendron seed add dendron.tldr
@@ -51,7 +51,7 @@ Adding `tldr` triggers a re-indexing of the newly added files  - the first-time 
 
 ![tldr tar and curl](https://org-dendron-public-assets.s3.amazonaws.com/images/tldr-lookup.gif)
 
-You can create [wiki links](https://link.dendron.so/6WvD) of commonly used commands in your daily journal for even easier access.
+You can create [wiki links](https://wiki.dendron.so/notes/3472226a-ff3c-432d-bf5d-10926f39f6c2/#wiki-links) of commonly used commands in your daily journal for even easier access.
 
 Over time, this will create a list of backlinks that will show you the commands you lookup the most often.
 
@@ -66,7 +66,7 @@ The story doesn't stop here. Over time, you end up publishing your own seeds on 
 
 ## Next
 
-It is still early days for the seed bank but hopefully, the above scenario was enough to give you some ideas. You can find the documentation to get started with the seed bank [here](https://link.dendron.so/6WvG)
+It is still early days for the seed bank but hopefully, the above scenario was enough to give you some ideas. You can find the documentation to get started with the seed bank [here](https://wiki.dendron.so/notes/6ff8cbb6-e4b8-449b-a967-277b76e4ecef/)
 
 With Dendron, we took elements of programming tools (eg. lookup, refactor, schemas) and applied it to the organization of general knowledge. With the seed bank, we are taking aspects of programming languages themselves (eg. composability, modularity) and applying it to knowledge. 
 

--- a/vault/blog.2021.2021-06-28-seed-bank.md
+++ b/vault/blog.2021.2021-06-28-seed-bank.md
@@ -2,7 +2,7 @@
 id: qTeL51LFD0Y8uC9ect7QV
 title: The Dendron Seed Bank - A Public Registry for General Knowledge
 desc: ''
-updated: 1635291259259
+updated: 1638757781614
 created: 1624562569744
 date: '2021-06-28'
 excerpt: "Github for knowledge"
@@ -22,7 +22,7 @@ Today, we are announcing the preview of the Seed Bank - a public registry for ge
 
 If you're familiar with package managers like npm, it's kind of like that but for any sort of information, not just code.
 
-The seed bank makes it easy to **discover, reference, and grow** information on things that you care about. This could be a guide on [personal knowledge management](http://pkm.dendron.so/) or a reference to everything [AWS](https://aws.dendron.so/)
+The seed bank makes it easy to **discover, reference, and grow** information on things that you care about. This could be a guide on [personal knowledge management](https://link.dendron.so/6Wu_) or a reference to everything [AWS](https://link.dendron.so/6Wv0)
 
 With the seed bank, you no longer need to start from zero when looking stuff up - rather, you have a single source of reference that you can grow over time.
 
@@ -39,7 +39,7 @@ You already use Dendron as a daily journal to track your tasks and you are tired
 
 Because the seed bank is currently in preview, you open up a shell and navigate to your workspace. Since you already have dendron open in vscode, you run `> Create new Integrated Terminal` to open up a shell. 
 
-Because you already have the [dendron-cli](https://wiki.dendron.so/notes/23a1b942-99af-45c8-8116-4f4bb7dccd21.html) installed, you can run the following command
+Because you already have the [dendron-cli](https://link.dendron.so/6Wv7) installed, you can run the following command
 
 ```
 dendron seed add dendron.tldr
@@ -51,7 +51,7 @@ Adding `tldr` triggers a re-indexing of the newly added files  - the first-time 
 
 ![tldr tar and curl](https://org-dendron-public-assets.s3.amazonaws.com/images/tldr-lookup.gif)
 
-You can create [wiki links](https://wiki.dendron.so/notes/3472226a-ff3c-432d-bf5d-10926f39f6c2.html) of commonly used commands in your daily journal for even easier access.
+You can create [wiki links](https://link.dendron.so/6WvD) of commonly used commands in your daily journal for even easier access.
 
 Over time, this will create a list of backlinks that will show you the commands you lookup the most often.
 
@@ -66,13 +66,13 @@ The story doesn't stop here. Over time, you end up publishing your own seeds on 
 
 ## Next
 
-It is still early days for the seed bank but hopefully, the above scenario was enough to give you some ideas. You can find the documentation to get started with the seed bank [here](https://wiki.dendron.so/notes/6ff8cbb6-e4b8-449b-a967-277b76e4ecef.html)
+It is still early days for the seed bank but hopefully, the above scenario was enough to give you some ideas. You can find the documentation to get started with the seed bank [here](https://link.dendron.so/6WvG)
 
 With Dendron, we took elements of programming tools (eg. lookup, refactor, schemas) and applied it to the organization of general knowledge. With the seed bank, we are taking aspects of programming languages themselves (eg. composability, modularity) and applying it to knowledge. 
 
 Our mission is to help **people** organize and make sense of any amount of information.  We are doing this by building the [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment) for general knowledge.
 
-Please give it a try and let us know what you think on [discord](https://discord.gg/AE3NRw9), [twitter](https://twitter.com/dendronhq) or [github](https://github.com/dendronhq/dendron/discussions).
+Please give it a try and let us know what you think on [discord](https://link.dendron.so/discord), [twitter](https://link.dendron.so/twitter) or [github](https://link.dendron.so/6WvK).
 
 ---
 

--- a/vault/blog.2021.2021-10-25-markdown-on-mobile.md
+++ b/vault/blog.2021.2021-10-25-markdown-on-mobile.md
@@ -2,7 +2,7 @@
 id: fDCVPEo3guCFWPdxokXHU
 title: Best Mobile Note-Taking Apps for Markdown
 desc: ''
-updated: 1635399661676
+updated: 1638757172711
 created: 1632684719327
 date: '2021-10-25'
 excerpt: An overview of mobile apps that work well with Markdown
@@ -15,7 +15,7 @@ publish: true
 
 ![Mobile phone sitting on top of a journal](https://org-dendron-public-assets.s3.amazonaws.com/images/blog-mobile-editor-header.png)
 
-On the desktop, Markdown notes can be taken in any plain-text editor of choice. If you're using [Dendron](https://www.dendron.so/), you can use VSCode/VSCodium as well as a suite of [powerful commands](https://wiki.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47.html) to manage your notes. Though, what happens when you walk out the door? It turns out that your phone can work with Markdown, too!
+On the desktop, Markdown notes can be taken in any plain-text editor of choice. If you're using [Dendron](https://link.dendron.so/home), you can use VSCode/VSCodium as well as a suite of [powerful commands](https://link.dendron.so/commands) to manage your notes. Though, what happens when you walk out the door? It turns out that your phone can work with Markdown, too!
 
 What we're looking at today:
 
@@ -41,7 +41,7 @@ What we're looking at today:
 
 _[Obsidian](https://obsidian.md/mobile)_ is a PKM (Personal Knowledge Management) tool that provides a sleek UI to Markdown files. It had the best mobile experience, for me, out of the apps I tested. Though it doesn't have git support built-in, other mobile apps can assist in providing that backend. I recommend [MGit (Android)](https://manichord.com/projects/mgit.html).
 
-Obsidian uses [wikilink style links](https://wiki.dendron.so/notes/9MZBqhrijEM4QpZRa5t08/) (ex. `[[my.other.note]]`), like Dendron, which is a nice plus.
+Obsidian uses [wikilink style links](https://link.dendron.so/6Wus) (ex. `[[my.other.note]]`), like Dendron, which is a nice plus.
 
 Paid options can assist note-takers with automatic syncing, publishing of notes, and other perks. Note that obsidian is free for personal use but requires at least a [paid commercial license for business use](https://help.obsidian.md/Licenses+%26+add-on+services/Commercial+license).
 
@@ -60,7 +60,7 @@ _[GitJournal](https://gitjournal.io/)_ has gained quite a bit of interest: it wo
 
 GitJournal also supports wikilinks and can therefore be used with Dendron and Obsidian.
 
-I'm really interested in seeing where GitJournal goes. I couldn't find other mobile apps that covered both notes in Markdown and git-integration, without needing to juggle multiple apps. With my [Dendron vaults](https://wiki.dendron.so/notes/6682fca0-65ed-402c-8634-94cd51463cc4.html), I mostly take [scratch notes](https://wiki.dendron.so/notes/5c213aa6-e4ba-49e8-85c5-1bdcb33ce202.html#scratch-note) or edit already-existing notes when using my phone. For more extensive usage, I hop on the laptop.
+I'm really interested in seeing where GitJournal goes. I couldn't find other mobile apps that covered both notes in Markdown and git-integration, without needing to juggle multiple apps. With my [Dendron vaults](https://link.dendron.so/6Wuw), I mostly take [scratch notes](https://link.dendron.so/6Wuz) or edit already-existing notes when using my phone. For more extensive usage, I hop on the laptop.
 
 I will say, though, that I ran into so many problems in trying to get my first demo repository setup that I stopped using GitJournal. Other users are running into issues at the moment having to do with syncing and setup, some of which might be tied to [a hard-coded expectation of branch names](https://github.com/GitJournal/GitJournal/issues/546) (such as `master`). I now use `mgit` for managing my repos, and Obsidian for managing notes.
 
@@ -104,7 +104,7 @@ Though, the cons here are that Markor only works on Android and needs another ap
 
 ## Other apps of interest
 
-There are many mobile note-taking solutions that work with Markdown. Below are some additional tools that [Dendrologists](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#dendrologist) have used for Markdown on the go.
+There are many mobile note-taking solutions that work with Markdown. Below are some additional tools that [Dendrologists](https://link.dendron.so/roles) have used for Markdown on the go.
 
 ### Markdown notes
 

--- a/vault/blog.2021.2021-10-25-markdown-on-mobile.md
+++ b/vault/blog.2021.2021-10-25-markdown-on-mobile.md
@@ -2,7 +2,7 @@
 id: fDCVPEo3guCFWPdxokXHU
 title: Best Mobile Note-Taking Apps for Markdown
 desc: ''
-updated: 1638757172711
+updated: 1638833233894
 created: 1632684719327
 date: '2021-10-25'
 excerpt: An overview of mobile apps that work well with Markdown
@@ -15,7 +15,7 @@ publish: true
 
 ![Mobile phone sitting on top of a journal](https://org-dendron-public-assets.s3.amazonaws.com/images/blog-mobile-editor-header.png)
 
-On the desktop, Markdown notes can be taken in any plain-text editor of choice. If you're using [Dendron](https://link.dendron.so/home), you can use VSCode/VSCodium as well as a suite of [powerful commands](https://link.dendron.so/commands) to manage your notes. Though, what happens when you walk out the door? It turns out that your phone can work with Markdown, too!
+On the desktop, Markdown notes can be taken in any plain-text editor of choice. If you're using [Dendron](https://dendron.so), you can use VSCode/VSCodium as well as a suite of [powerful commands](https://wiki.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47/) to manage your notes. Though, what happens when you walk out the door? It turns out that your phone can work with Markdown, too!
 
 What we're looking at today:
 
@@ -41,7 +41,7 @@ What we're looking at today:
 
 _[Obsidian](https://obsidian.md/mobile)_ is a PKM (Personal Knowledge Management) tool that provides a sleek UI to Markdown files. It had the best mobile experience, for me, out of the apps I tested. Though it doesn't have git support built-in, other mobile apps can assist in providing that backend. I recommend [MGit (Android)](https://manichord.com/projects/mgit.html).
 
-Obsidian uses [wikilink style links](https://link.dendron.so/6Wus) (ex. `[[my.other.note]]`), like Dendron, which is a nice plus.
+Obsidian uses [wikilink style links](https://wiki.dendron.so/notes/3472226a-ff3c-432d-bf5d-10926f39f6c2/#wiki-links) (ex. `[[my.other.note]]`), like Dendron, which is a nice plus.
 
 Paid options can assist note-takers with automatic syncing, publishing of notes, and other perks. Note that obsidian is free for personal use but requires at least a [paid commercial license for business use](https://help.obsidian.md/Licenses+%26+add-on+services/Commercial+license).
 
@@ -60,7 +60,7 @@ _[GitJournal](https://gitjournal.io/)_ has gained quite a bit of interest: it wo
 
 GitJournal also supports wikilinks and can therefore be used with Dendron and Obsidian.
 
-I'm really interested in seeing where GitJournal goes. I couldn't find other mobile apps that covered both notes in Markdown and git-integration, without needing to juggle multiple apps. With my [Dendron vaults](https://link.dendron.so/6Wuw), I mostly take [scratch notes](https://link.dendron.so/6Wuz) or edit already-existing notes when using my phone. For more extensive usage, I hop on the laptop.
+I'm really interested in seeing where GitJournal goes. I couldn't find other mobile apps that covered both notes in Markdown and git-integration, without needing to juggle multiple apps. With my [Dendron vaults](https://wiki.dendron.so/notes/6682fca0-65ed-402c-8634-94cd51463cc4/), I mostly take [scratch notes](https://wiki.dendron.so/notes/5c213aa6-e4ba-49e8-85c5-1bdcb33ce202/#scratch-note) or edit already-existing notes when using my phone. For more extensive usage, I hop on the laptop.
 
 I will say, though, that I ran into so many problems in trying to get my first demo repository setup that I stopped using GitJournal. Other users are running into issues at the moment having to do with syncing and setup, some of which might be tied to [a hard-coded expectation of branch names](https://github.com/GitJournal/GitJournal/issues/546) (such as `master`). I now use `mgit` for managing my repos, and Obsidian for managing notes.
 
@@ -104,7 +104,7 @@ Though, the cons here are that Markor only works on Android and needs another ap
 
 ## Other apps of interest
 
-There are many mobile note-taking solutions that work with Markdown. Below are some additional tools that [Dendrologists](https://link.dendron.so/roles) have used for Markdown on the go.
+There are many mobile note-taking solutions that work with Markdown. Below are some additional tools that [Dendrologists](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7/#dendrologist) have used for Markdown on the go.
 
 ### Markdown notes
 

--- a/vault/blog.2021.2021-12-08-dendron-with-netlify.md
+++ b/vault/blog.2021.2021-12-08-dendron-with-netlify.md
@@ -2,7 +2,7 @@
 id: 7h7zZkjF4Yqz8XSrHS1je
 title: "Share Your Notes Online: Publish Dendron with Netlify and GitHub"
 desc: ''
-updated: 1638395542181
+updated: 1638395819536
 created: 1638387034460
 image:
   url: >-
@@ -17,9 +17,9 @@ published: false
 
 ![Logos for GitHub, Netlify, and Dendron](https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png)
 
-[Dendron](https://www.dendron.so/) helps people and products organize with notes, docs, and knowledge of all the things. Let's so how easy it is to publish, and have a static site hosted on [Netlify](https://www.netlify.com/)!
+[Dendron](https://www.dendron.so/) helps people and products organize with notes, docs, and knowledge of all the things. Let's see how easy it is to publish and have a static site hosted on [Netlify](https://www.netlify.com/)!
 
-You'll learn how to publish your Dendron notes using Netlify and GitHub, [looking like this demo website](https://dendron-example.netlify.app/). This tutorial assumes that you have basic knowledge of GitHub and Visual Studio Code (VSCode).
+You'll learn how to publish your Dendron notes using Netlify and GitHub, which looks like [this demo website](https://dendron-example.netlify.app/). This tutorial assumes that you have basic knowledge of GitHub and Visual Studio Code (VSCode).
 
 - [Join GitHub](https://github.com/join)
   - [Learn: Git and GitHub](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/GitHub)
@@ -30,7 +30,7 @@ You'll learn how to publish your Dendron notes using Netlify and GitHub, [lookin
 
 ## Part 1: GitHub
 
-When logged into GitHub, [click here](https://github.com/dendronhq/template.publish.netlify/generate) to generate a new Dendron Workspace pre-configured to publish to Netlify. If you're wondering, we're using [this template](https://github.com/dendronhq/template.publish.netlify) on GitHub.
+When logged into GitHub, [click here](https://github.com/dendronhq/template.publish.netlify/generate) to generate a new Dendron Workspace pre-configured for Netlify publishing. If you're wondering, we're using [this template](https://github.com/dendronhq/template.publish.netlify) on GitHub.
 
 ![Generating a new GitHub repo from the Dendron Netlify template](https://org-dendron-public-assets.s3.amazonaws.com/images/github-create-workspace-netlify.gif)
 
@@ -48,7 +48,7 @@ When logged into Netlify, you start on your `Team Overview` page.
 
 - Click `New site from Git`
 - Under `Connect to Git provider`, select `GitHub`
-  - You'll be asked configure Dendron for permissions. It's best practice to go with `Only select repositories`, and selecting the repository you made from the template.
+  - You'll be asked configure Dendron for permissions. It's best practice to go with `Only select repositories`, and selecting the repository you made from the template
 
 Once permissions are configured, select the repository in Netlify. There is no need to change any of default values, since the GitHub template is providing them from [`netlify.toml`](https://github.com/dendronhq/template.publish.netlify/blob/main/netlify.toml). Scroll to the bottom, and click `Deploy site`.
 

--- a/vault/blog.2021.2021-12-08-dendron-with-netlify.md
+++ b/vault/blog.2021.2021-12-08-dendron-with-netlify.md
@@ -2,12 +2,12 @@
 id: 7h7zZkjF4Yqz8XSrHS1je
 title: "Share Your Notes Online: Publish Dendron with Netlify and GitHub"
 desc: ''
-updated: 1638755391949
+updated: 1638755776711
 created: 1638387034460
 image:
   url: >-
     https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png
-  alt: Visual Studio Code logo
+  alt: Logos for Dendron, GitHub, and Netlify
 date: '2021-12-08'
 excerpt: >-
   Publishing Dendron notes, using Netlify and GitHub, can be done quickly with the Dendron publishing template!

--- a/vault/blog.2021.2021-12-08-dendron-with-netlify.md
+++ b/vault/blog.2021.2021-12-08-dendron-with-netlify.md
@@ -2,13 +2,13 @@
 id: 7h7zZkjF4Yqz8XSrHS1je
 title: "Share Your Notes Online: Publish Dendron with Netlify and GitHub"
 desc: ''
-updated: 1638395345638
+updated: 1638395542181
 created: 1638387034460
 image:
   url: >-
     https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png
   alt: Visual Studio Code logo
-date: '2021-11-22'
+date: '2021-12-08'
 excerpt: >-
   Publishing Dendron notes, using Netlify and GitHub, can be done quickly with the Dendron publishing template!
 author: Derek Ardolf

--- a/vault/blog.2021.2021-12-08-dendron-with-netlify.md
+++ b/vault/blog.2021.2021-12-08-dendron-with-netlify.md
@@ -1,0 +1,97 @@
+---
+id: 7h7zZkjF4Yqz8XSrHS1je
+title: "Share Your Notes Online: Publish Dendron with Netlify and GitHub"
+desc: ''
+updated: 1638395345638
+created: 1638387034460
+image:
+  url: >-
+    https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png
+  alt: Visual Studio Code logo
+date: '2021-11-22'
+excerpt: >-
+  Publishing Dendron notes, using Netlify and GitHub, can be done quickly with the Dendron publishing template!
+author: Derek Ardolf
+published: false
+---
+
+![Logos for GitHub, Netlify, and Dendron](https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png)
+
+[Dendron](https://www.dendron.so/) helps people and products organize with notes, docs, and knowledge of all the things. Let's so how easy it is to publish, and have a static site hosted on [Netlify](https://www.netlify.com/)!
+
+You'll learn how to publish your Dendron notes using Netlify and GitHub, [looking like this demo website](https://dendron-example.netlify.app/). This tutorial assumes that you have basic knowledge of GitHub and Visual Studio Code (VSCode).
+
+- [Join GitHub](https://github.com/join)
+  - [Learn: Git and GitHub](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/GitHub)
+- [Join Netlify](https://app.netlify.com/signup)
+- [Download Visual Studio Code](https://code.visualstudio.com/)
+
+> This uses a brand new Dendron Workspace you can later configure to work with your own vaults. Do you already have a workspace you'd prefer using? Reference the Dendron docs for in-depth details on how the template, and other workspaces, can publish to Netlify: [Publishing with Netlify](https://wiki.dendron.so/notes/yetuum6o9wZi6eVJQBbQb).
+
+## Part 1: GitHub
+
+When logged into GitHub, [click here](https://github.com/dendronhq/template.publish.netlify/generate) to generate a new Dendron Workspace pre-configured to publish to Netlify. If you're wondering, we're using [this template](https://github.com/dendronhq/template.publish.netlify) on GitHub.
+
+![Generating a new GitHub repo from the Dendron Netlify template](https://org-dendron-public-assets.s3.amazonaws.com/images/github-create-workspace-netlify.gif)
+
+Nice! That's all we need to do for this minimal Dendron setup.
+
+> Note that this tutorial will work with both private and public repositories.
+
+## Part 2: Netlify
+
+The rest of the steps are done in the Netlify portal.
+
+### Step 1: Import your repository
+
+When logged into Netlify, you start on your `Team Overview` page.
+
+- Click `New site from Git`
+- Under `Connect to Git provider`, select `GitHub`
+  - You'll be asked configure Dendron for permissions. It's best practice to go with `Only select repositories`, and selecting the repository you made from the template.
+
+Once permissions are configured, select the repository in Netlify. There is no need to change any of default values, since the GitHub template is providing them from [`netlify.toml`](https://github.com/dendronhq/template.publish.netlify/blob/main/netlify.toml). Scroll to the bottom, and click `Deploy site`.
+
+![Selecting the GitHub repository in the Netlify import wizard](https://org-dendron-public-assets.s3.amazonaws.com/images/netlify-import-git-repo.gif)
+
+Your website should now be building!
+
+> For more information on Netlify app permissions, to GitHub, refer to [Netlify Docs: Authentication with the Netlify GitHub App](https://docs.netlify.com/configure-builds/repo-permissions-linking/#authentication-with-the-netlify-github-app)
+
+### Step 2: Configure your website name
+
+By default, Netlify generates a random combination of strings. In the example so far, the website is named `elastic-hugle-37bfd5.netlify.app`. If you don't want to own your own domain name, you can at least change the `elastic-hugle-37bfd5` section.
+
+- `Site settings`
+- Under `Site information`, click `Change site name`
+- Enter new name, and if it is available, click `Save`
+
+![Changing the Netlify App subdomain name](https://org-dendron-public-assets.s3.amazonaws.com/images/netlify-change-site-name.gif)
+
+> For more information on custom domains, beyond the above, refer to [Netlify Docs: Custom domains](https://docs.netlify.com/domains-https/custom-domains/)
+
+### Step 3: View deploy status
+
+Under the `Deploys` tab, in Netlify, you can view the status of your website. This is where build information will be posted whenever new commits are posted to the `main` branch of your repository on GitHub.
+
+This is a great way to check whether build have failed, or are still in progress. If you run into any errors, and aren't sure what to do next, jump into the [Dendron Discord](https://discord.com/invite/xrKTUStHNZ) where we have a `#questions` channel.
+
+## Summary
+
+You're done! From now on, all new commits you make to your repository on GitHub will trigger a new publihing update to your website.
+
+In this tutorial, you learned how to:
+
+- Create a pre-configured, minimal Dendron Workspace from a template
+- Import a repository into Netlify
+- Create a custom name for your Netlify website
+- View deploy status in Netlify
+
+## Next steps
+
+Now what? Publishing is set, but Dendron isn't just for what you want to share with the world. It's an open source, local-first knowledge management solution that scales with everything you do.
+
+* [Dendron Getting Started Guide](https://wiki.dendron.so/notes/678c77d9-ef2c-4537-97b5-64556d6337f1/)
+* [Dendron FAQ](https://wiki.dendron.so/notes/683740e3-70ce-4a47-a1f4-1f140e80b558/)
+* [Dendron Concepts](https://wiki.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50/)
+* [Netlify Docs Home Page](https://docs.netlify.com/)

--- a/vault/blog.2021.2021-12-08-dendron-with-netlify.md
+++ b/vault/blog.2021.2021-12-08-dendron-with-netlify.md
@@ -2,7 +2,7 @@
 id: 7h7zZkjF4Yqz8XSrHS1je
 title: "Share Your Notes Online: Publish Dendron with Netlify and GitHub"
 desc: ''
-updated: 1638755776711
+updated: 1638833392156
 created: 1638387034460
 image:
   url: >-
@@ -17,7 +17,7 @@ published: false
 
 ![Logos for GitHub, Netlify, and Dendron](https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png)
 
-[Dendron](https://link.dendron.so/home) helps people and products organize with notes, docs, and knowledge of all the things. Let's see how easy it is to publish and have a static site hosted on [Netlify](https://www.netlify.com/)!
+[Dendron](https://dendron.so) helps people and products organize with notes, docs, and knowledge of all the things. Let's see how easy it is to publish and have a static site hosted on [Netlify](https://www.netlify.com/)!
 
 You'll learn how to publish your Dendron notes using Netlify and GitHub, which looks like [this demo website](https://link.dendron.so/netlify-demo). This tutorial assumes that you have basic knowledge of GitHub and Visual Studio Code (VSCode).
 
@@ -26,7 +26,7 @@ You'll learn how to publish your Dendron notes using Netlify and GitHub, which l
 - [Join Netlify](https://app.netlify.com/signup)
 - [Download Visual Studio Code](https://code.visualstudio.com/)
 
-> This uses a brand new Dendron Workspace you can later configure to work with your own vaults. Do you already have a workspace you'd prefer using? Reference the Dendron docs for in-depth details on how the template, and other workspaces, can publish to Netlify: [Publishing with Netlify](https://link.dendron.so/6WuK).
+> This uses a brand new Dendron Workspace you can later configure to work with your own vaults. Do you already have a workspace you'd prefer using? Reference the Dendron docs for in-depth details on how the template, and other workspaces, can publish to Netlify: [Publishing with Netlify](https://wiki.dendron.so/notes/yg3EL1x9fEe4NMqxUC3jP/).
 
 ## Part 1: GitHub
 
@@ -91,8 +91,8 @@ In this tutorial, you learned how to:
 
 Now what? Publishing is set, but Dendron isn't just for what you want to share with the world. It's an open source, local-first knowledge management solution that scales as you do.
 
-* [Dendron Getting Started Guide](https://link.dendron.so/get-started)
-* [Dendron Publishing Guide](https://link.dendron.so/6WuT)
-* [Dendron FAQ](https://link.dendron.so/faq)
-* [Dendron Concepts](https://link.dendron.so/concepts)
+* [Dendron Getting Started Guide](https://wiki.dendron.so/notes/678c77d9-ef2c-4537-97b5-64556d6337f1/)
+* [Dendron Publishing Guide](https://wiki.dendron.so/notes/4ushYTDoX0TYQ1FDtGQSg/)
+* [Dendron FAQ](https://wiki.dendron.so/notes/683740e3-70ce-4a47-a1f4-1f140e80b558/)
+* [Dendron Concepts](https://wiki.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50/)
 * [Netlify Docs Home Page](https://docs.netlify.com/)

--- a/vault/blog.2021.2021-12-08-dendron-with-netlify.md
+++ b/vault/blog.2021.2021-12-08-dendron-with-netlify.md
@@ -2,7 +2,7 @@
 id: 7h7zZkjF4Yqz8XSrHS1je
 title: "Share Your Notes Online: Publish Dendron with Netlify and GitHub"
 desc: ''
-updated: 1638395819536
+updated: 1638755391949
 created: 1638387034460
 image:
   url: >-
@@ -17,24 +17,24 @@ published: false
 
 ![Logos for GitHub, Netlify, and Dendron](https://org-dendron-public-assets.s3.amazonaws.com/images/blog-header-dendron-netlify.png)
 
-[Dendron](https://www.dendron.so/) helps people and products organize with notes, docs, and knowledge of all the things. Let's see how easy it is to publish and have a static site hosted on [Netlify](https://www.netlify.com/)!
+[Dendron](https://link.dendron.so/home) helps people and products organize with notes, docs, and knowledge of all the things. Let's see how easy it is to publish and have a static site hosted on [Netlify](https://www.netlify.com/)!
 
-You'll learn how to publish your Dendron notes using Netlify and GitHub, which looks like [this demo website](https://dendron-example.netlify.app/). This tutorial assumes that you have basic knowledge of GitHub and Visual Studio Code (VSCode).
+You'll learn how to publish your Dendron notes using Netlify and GitHub, which looks like [this demo website](https://link.dendron.so/netlify-demo). This tutorial assumes that you have basic knowledge of GitHub and Visual Studio Code (VSCode).
 
 - [Join GitHub](https://github.com/join)
   - [Learn: Git and GitHub](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/GitHub)
 - [Join Netlify](https://app.netlify.com/signup)
 - [Download Visual Studio Code](https://code.visualstudio.com/)
 
-> This uses a brand new Dendron Workspace you can later configure to work with your own vaults. Do you already have a workspace you'd prefer using? Reference the Dendron docs for in-depth details on how the template, and other workspaces, can publish to Netlify: [Publishing with Netlify](https://wiki.dendron.so/notes/yetuum6o9wZi6eVJQBbQb).
+> This uses a brand new Dendron Workspace you can later configure to work with your own vaults. Do you already have a workspace you'd prefer using? Reference the Dendron docs for in-depth details on how the template, and other workspaces, can publish to Netlify: [Publishing with Netlify](https://link.dendron.so/6WuK).
 
 ## Part 1: GitHub
 
-When logged into GitHub, [click here](https://github.com/dendronhq/template.publish.netlify/generate) to generate a new Dendron Workspace pre-configured for Netlify publishing. If you're wondering, we're using [this template](https://github.com/dendronhq/template.publish.netlify) on GitHub.
+When logged into GitHub, [click here](https://link.dendron.so/6WuJ) to generate a new Dendron Workspace pre-configured for Netlify publishing. If you're wondering, we're using [this template](https://link.dendron.so/6WuI) on GitHub.
 
 ![Generating a new GitHub repo from the Dendron Netlify template](https://org-dendron-public-assets.s3.amazonaws.com/images/github-create-workspace-netlify.gif)
 
-Nice! That's all we need to do for this minimal Dendron setup.
+Nice! That's all we need to do for this minimal Dendron setup. To understand what is going on behind the scenes, you can read the [template README](https://link.dendron.so/6WuI).
 
 > Note that this tutorial will work with both private and public repositories.
 
@@ -50,7 +50,7 @@ When logged into Netlify, you start on your `Team Overview` page.
 - Under `Connect to Git provider`, select `GitHub`
   - You'll be asked configure Dendron for permissions. It's best practice to go with `Only select repositories`, and selecting the repository you made from the template
 
-Once permissions are configured, select the repository in Netlify. There is no need to change any of default values, since the GitHub template is providing them from [`netlify.toml`](https://github.com/dendronhq/template.publish.netlify/blob/main/netlify.toml). Scroll to the bottom, and click `Deploy site`.
+Once permissions are configured, select the repository in Netlify. There is no need to change any of default values, since the GitHub template is providing them from [`netlify.toml`](https://link.dendron.so/6WuS). Scroll to the bottom, and click `Deploy site`.
 
 ![Selecting the GitHub repository in the Netlify import wizard](https://org-dendron-public-assets.s3.amazonaws.com/images/netlify-import-git-repo.gif)
 
@@ -74,7 +74,7 @@ By default, Netlify generates a random combination of strings. In the example so
 
 Under the `Deploys` tab, in Netlify, you can view the status of your website. This is where build information will be posted whenever new commits are posted to the `main` branch of your repository on GitHub.
 
-This is a great way to check whether build have failed, or are still in progress. If you run into any errors, and aren't sure what to do next, jump into the [Dendron Discord](https://discord.com/invite/xrKTUStHNZ) where we have a `#questions` channel.
+This is a great way to check whether build have failed, or are still in progress. If you run into any errors, and aren't sure what to do next, jump into the [Dendron Discord](https://link.dendron.so/discord) where we have a `#questions` channel.
 
 ## Summary
 
@@ -89,9 +89,10 @@ In this tutorial, you learned how to:
 
 ## Next steps
 
-Now what? Publishing is set, but Dendron isn't just for what you want to share with the world. It's an open source, local-first knowledge management solution that scales with everything you do.
+Now what? Publishing is set, but Dendron isn't just for what you want to share with the world. It's an open source, local-first knowledge management solution that scales as you do.
 
-* [Dendron Getting Started Guide](https://wiki.dendron.so/notes/678c77d9-ef2c-4537-97b5-64556d6337f1/)
-* [Dendron FAQ](https://wiki.dendron.so/notes/683740e3-70ce-4a47-a1f4-1f140e80b558/)
-* [Dendron Concepts](https://wiki.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50/)
+* [Dendron Getting Started Guide](https://link.dendron.so/get-started)
+* [Dendron Publishing Guide](https://link.dendron.so/6WuT)
+* [Dendron FAQ](https://link.dendron.so/faq)
+* [Dendron Concepts](https://link.dendron.so/concepts)
 * [Netlify Docs Home Page](https://docs.netlify.com/)

--- a/vault/blog.subscribe.md
+++ b/vault/blog.subscribe.md
@@ -2,7 +2,7 @@
 id: jCoayBWmLrfn2W4WrOR9x
 title: Subscribe
 desc: ''
-updated: 1637789071431
+updated: 1638832455979
 created: 1634853707725
 ---
 
@@ -24,10 +24,9 @@ Enjoy the blog? Subscribe to our newsletter!
 
 Newsletters not your thing? You can also follow us elsewhere on the interwebs:
 
-* Join [Dendron on Discord](https://discord.com/invite/xrKTUStHNZ)
-* Register for [Dendron Events on Luma](https://lu.ma/community/com-lTfMsAZEWSwLJJL/calendar)
-* Follow [Dendron on Twitter](https://twitter.com/dendronhq)
-* Checkout [Dendron on GitHub](https://github.com/dendronhq)
+* Join [Dendron on Discord](https://link.dendron.so/discord)
+* Follow [Dendron on Twitter](https://link.dendron.so/twitter)
+* Checkout [Dendron on GitHub](https://link.dendron.so/github)
 
 ---
 


### PR DESCRIPTION
Depends on the Netlify docs getting published to `wiki.dendron.so` as it if referenced for more in-depth publishing info.

- https://github.com/dendronhq/dendron-site/pull/299