### PR TITLE
Set the default value of `siteBanner` to `none`

### DIFF
--- a/dendron.yml
+++ b/dendron.yml
@@ -108,4 +108,4 @@ publishing:
         editViewMode: tree
         editRepository: https://github.com/dendronhq/dendron-blog
     enablePrettyLinks: true
-    siteBanner: custom
+    siteBanner: none


### PR DESCRIPTION
Fix #25 

Also, if the original intent of the code below was to run only once, perhaps it would be better to use Ref, React has never guaranteed that `useEffect` will only be called once.
```
  React.useEffect(() => {
    const BannerFile =
      ConfigUtils.getPublishing(config).siteBanner === "custom"
        ? "BannerAlert.tsx"
        : "NoOp";
    logger.info({ ctx: "loading banner", BannerFile });
    BannerAlert = require(`../custom/${BannerFile}`).default;
  }, []);
```